### PR TITLE
pytools python3 working container

### DIFF
--- a/derivatives/Dockerfile.pytools
+++ b/derivatives/Dockerfile.pytools
@@ -1,9 +1,9 @@
 #basic dev container with extra python packages on top
 FROM ldmx/dev:latest
 # modify container entry point to put cache and config directories in LDMX_BASE
-RUN echo "export XDG_CONFIG_HOME=\"\$LDMX_BASE\"/.config" >> /home/ldmx.sh &&\
-    echo "export XDG_CACHE_HOME=\"\$LDMX_BASE\"/.cache"   >> /home/ldmx.sh
-RUN cat /home/ldmx.sh
+RUN sed -i '/export\ CMAKE.*/ a export XDG_CONFIG_HOME=\$LDMX_BASE/.rootpy/config' /home/ldmx.sh &&\
+    sed -i '/export\ CMAKE.*/ a export XDG_CACHE_HOME=\$LDMX_BASE/.rootpy/cache'   /home/ldmx.sh &&\
+    sed -i '/export\ CMAKE.*/ a #Change cache and config location of rootpy'      /home/ldmx.sh
 # update and install packages
 RUN apt-get update &&\
     apt-get install python3-pip -y &&\

--- a/derivatives/Dockerfile.pytools
+++ b/derivatives/Dockerfile.pytools
@@ -1,5 +1,10 @@
-#basic dev container with uproot on top
+#basic dev container with extra python packages on top
 FROM ldmx/dev:latest
+# modify container entry point to put cache and config directories in LDMX_BASE
+RUN echo "export XDG_CONFIG_HOME=\"\$LDMX_BASE\"/.config" >> /home/ldmx.sh &&\
+    echo "export XDG_CACHE_HOME=\"\$LDMX_BASE\"/.cache"   >> /home/ldmx.sh
+RUN cat /home/ldmx.sh
+# update and install packages
 RUN apt-get update &&\
     apt-get install python3-pip -y &&\
     ./home/ldmx.sh . python3 -m pip install --upgrade --no-cache-dir \
@@ -7,3 +12,4 @@ RUN apt-get update &&\
         numpy \
         rootpy \
         matplotlib
+


### PR DESCRIPTION
I am patching up a derivative container, here are the details.

## Derivative Description
### What new packages does this derivative add to the development container?
PyROOT shipped with ROOT was built with python3 and all the packages below were installed with python3.
- uproot
- rootpy
- matplotlib
- numpy

### What do you want to tag this container?
`pytools`

## Check List
- [x] I successfully built the container using docker
- [ ] @jmlazaro25  was able to test the container with ldmx-sw using `source ldmx-sw/scripts/ldmx-env.sh . my-tag local`
- [x] I put my Dockerfile in the `derivatives` directory and named it `Dockerfile.my-tag`
- [x] I added my container to the list of derivatives to be built in `.github/workflows/derivatives.yml`:

