### PR TITLE
python2 pytools container

### DIFF
--- a/.github/workflows/derivatives.yml
+++ b/.github/workflows/derivatives.yml
@@ -23,3 +23,16 @@ jobs:
         dockerfile: derivatives/Dockerfile.pytools
         tags: pytools
 
+  py2tools:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build It!
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: ldmx/dev
+        path: derivatives
+        dockerfile: derivatives/Dockerfile.py2tools
+        tags: py2tools

--- a/derivatives/Dockerfile.py2tools
+++ b/derivatives/Dockerfile.py2tools
@@ -1,0 +1,8 @@
+#basic dev container with uproot on top
+FROM ldmx/dev:pyroot2
+RUN apt-get update &&\
+    apt-get install python-pip -y &&\
+    ./home/ldmx.sh . pip install --upgrade --no-cache-dir \
+        uproot \
+        numpy \
+        matplotlib

--- a/derivatives/README.md
+++ b/derivatives/README.md
@@ -1,9 +1,6 @@
 ## Derivatives
 
 Derivatives of the development container are useful for incorporating packages that aren't inside of the minimal development container.
-The first example of this is `uproot`.
-Several collaborators use `uproot` along with the libraries compiled inside the development container to do analyses.
-This means that those collaborators **need** to have `uproot` inside of the container.
 
 ### Current List of Derivatives and the Corresponding Tag
 To use a given derivative tag, you need to pass it to the ldmx-sw environment script:
@@ -13,7 +10,8 @@ source ldmx-sw/scripts/ldmx-env.sh . tag
 
 | Tag | Extra Packages |
 |---|---|
-|`pytools`|uproot,rootpy,numpy,matplotlib|
+|`pytools`|uproot,rootpy,numpy,matplotlib,PyROOT in python3|
+|`py2tools`|uproot,numpy,matplotlib,PyROOT in python2|
 
 ### Documentation
 After developing a derivative dockerfile (i.e. making sure it builds successfully and runs the way you want it to),


### PR DESCRIPTION
I am adding a new derivative container, here are the details.

## Derivative Description
### What new packages does this derivative add to the development container?
PyROOT was built with python2 and all of the packages below were installed inside of python2.
- uproot
- numpy
- matplotlib

### What do you want to tag this container?
`py2tools`

## Check List
- [x] I successfully built the container using docker
- [ ] @bryngemark  was able to test this container with ldmx-sw using `source ldmx-sw/scripts/ldmx-env.sh . my-tag local`
- [x] I put my Dockerfile in the `derivatives` directory and named it `Dockerfile.my-tag`
- [x] I added my container to the list of derivatives to be built in `.github/workflows/derivatives.yml`:
