### PR TITLE
python3-based pytools working container

### DIFF
--- a/derivatives/Dockerfile.pytools
+++ b/derivatives/Dockerfile.pytools
@@ -1,15 +1,36 @@
-#basic dev container with extra python packages on top
+# basic dev container with extra ml tools
 FROM ldmx/dev:latest
+
 # modify container entry point to put cache and config directories in LDMX_BASE
 RUN sed -i '/export\ CMAKE.*/ a export XDG_CONFIG_HOME=\$LDMX_BASE/.rootpy/config' /home/ldmx.sh &&\
     sed -i '/export\ CMAKE.*/ a export XDG_CACHE_HOME=\$LDMX_BASE/.rootpy/cache'   /home/ldmx.sh &&\
     sed -i '/export\ CMAKE.*/ a #Change cache and config location of rootpy'      /home/ldmx.sh
-# update and install packages
+
+# enable sudo
+RUN apt-get install sudo
+RUN adduser --disabled-password --gecos '' admin
+RUN adduser admin sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# remove old cmake
+RUN sudo apt-get remove -y --purge cmake
+RUN hash -r
+
+# install new cmake
+RUN sudo apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
+RUN sudo wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+RUN sudo apt-get update
+RUN sudo apt-get install -y cmake
+RUN sudo apt-get install kitware-archive-keyring
+
+# install other packages
 RUN apt-get update &&\
     apt-get install python3-pip -y &&\
     ./home/ldmx.sh . python3 -m pip install --upgrade --no-cache-dir \
         uproot \
         numpy \
         rootpy \
-        matplotlib
-
+        matplotlib \
+        xgboost \
+        sklearn

--- a/derivatives/Dockerfile.pytools
+++ b/derivatives/Dockerfile.pytools
@@ -1,9 +1,9 @@
 #basic dev container with extra python packages on top
 FROM ldmx/dev:latest
 # modify container entry point to put cache and config directories in LDMX_BASE
-RUN echo "export XDG_CONFIG_HOME=\"\$LDMX_BASE\"/.config" >> /home/ldmx.sh &&\
-    echo "export XDG_CACHE_HOME=\"\$LDMX_BASE\"/.cache"   >> /home/ldmx.sh
-RUN cat /home/ldmx.sh
+RUN sed -i '/export\ CMAKE.*/ a export XDG_CONFIG_HOME=\$LDMX_BASE/.rootpy/config' /home/ldmx.sh &&\
+    sed -i '/export\ CMAKE.*/ a export XDG_CACHE_HOME=\$LDMX_BASE/.rootpy/cache'   /home/ldmx.sh &&\
+    sed -i '/export\ CMAKE.*/ a #Change cache and config location of rootpy'      /home/ldmx.sh
 # update and install packages
 RUN apt-get update &&\
     apt-get install python3-pip -y &&\

--- a/derivatives/Dockerfile.pytools
+++ b/derivatives/Dockerfile.pytools
@@ -6,23 +6,18 @@ RUN sed -i '/export\ CMAKE.*/ a export XDG_CONFIG_HOME=\$LDMX_BASE/.rootpy/confi
     sed -i '/export\ CMAKE.*/ a export XDG_CACHE_HOME=\$LDMX_BASE/.rootpy/cache'   /home/ldmx.sh &&\
     sed -i '/export\ CMAKE.*/ a #Change cache and config location of rootpy'      /home/ldmx.sh
 
-# enable sudo
-RUN apt-get install sudo
-RUN adduser --disabled-password --gecos '' admin
-RUN adduser admin sudo
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
 # remove old cmake
-RUN sudo apt-get remove -y --purge cmake
-RUN hash -r
+RUN apt-get remove -y --purge cmake && hash -r
 
 # install new cmake
-RUN sudo apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
-RUN sudo wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-RUN sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-RUN sudo apt-get update
-RUN sudo apt-get install -y cmake
-RUN sudo apt-get install kitware-archive-keyring
+RUN apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget &&\
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null |\
+        gpg --dearmor - |\
+        tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null &&\
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' &&\
+    apt-get update &&\
+    apt-get install -y cmake &&\
+    apt-get install kitware-archive-keyring
 
 # install other packages
 RUN apt-get update &&\

--- a/derivatives/Dockerfile.pytools
+++ b/derivatives/Dockerfile.pytools
@@ -1,5 +1,10 @@
-#basic dev container with uproot on top
+#basic dev container with extra python packages on top
 FROM ldmx/dev:latest
+# modify container entry point to put cache and config directories in LDMX_BASE
+RUN echo "export XDG_CONFIG_HOME=\"\$LDMX_BASE\"/.config" >> /home/ldmx.sh &&\
+    echo "export XDG_CACHE_HOME=\"\$LDMX_BASE\"/.cache"   >> /home/ldmx.sh
+RUN cat /home/ldmx.sh
+# update and install packages
 RUN apt-get update &&\
     apt-get install python3-pip -y &&\
     ./home/ldmx.sh . python3 -m pip install --upgrade --no-cache-dir \
@@ -7,3 +12,4 @@ RUN apt-get update &&\
         numpy \
         rootpy \
         matplotlib
+

--- a/derivatives/README.md
+++ b/derivatives/README.md
@@ -13,7 +13,7 @@ source ldmx-sw/scripts/ldmx-env.sh . tag
 
 | Tag | Extra Packages |
 |---|---|
-|`pytools`|uproot,rootpy,numpy,matplotlib|
+|`pytools`|uproot,rootpy,numpy,matplotlib,xgboost,sklearn,PyROOT in python3|
 
 ### Documentation
 After developing a derivative dockerfile (i.e. making sure it builds successfully and runs the way you want it to),


### PR DESCRIPTION
I am patching up a derivative container, here are the details.

# Derivative Description
What new packages does this derivative add to the development container?
PyROOT shipped with ROOT was built with python3 and all the packages below were installed with python3.
- uproot
- rootpy
- matplotlib
- numpy

## What do you want to tag this container?
`pytools`

## Check List
- [x] I successfully built the container using docker
- [x] @jmlazaro25 was able to test the container with ldmx-sw using source ldmx-sw/scripts/ldmx-env.sh . my-tag local
- [x] I put my Dockerfile in the derivatives directory and named it Dockerfile.my-tag
- [x] I added my container to the list of derivatives to be built in .github/workflows/derivatives.yml:
