### PR TITLE
Iss29 - Automatic testing through GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,17 @@ name: Build
 # only build if push changes to files involved in the build
 on:
   push:
-    branches: [ main ]
-    paths: [ 'ldmx.sh' , 'Dockerfile' , 'install-scripts/**' , '**base.yml' ]
+    branches:
+      - main
+    paths: 
+      - 'ldmx.sh' 
+      - 'Dockerfile'
+      - 'install-scripts/**'
+      - '**base.yml'
   pull_request:
-    branches: [ main ]
+    branches: 
+      - main
+  release:
 
 # the jobs are the different container tags that we want built
 jobs:
@@ -15,11 +22,11 @@ jobs:
   #     this is the container that pretty much everyone in ldmx-sw should use
   basic:
     runs-on: ubuntu-latest
-#    services:
-#      registry:
-#        image: registry:2
-#        ports:
-#          - 5000:5000
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
     -
       name: Setup QEMU
@@ -27,8 +34,8 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-#      with:
-#        driver-opts: network=host
+      with:
+        driver-opts: network=host
     - 
       name: Get Build Context
       uses: actions/checkout@v2
@@ -37,38 +44,39 @@ jobs:
       id: generate_tag
       run: |
           _tag=latest
-          if [ "${{ github.event_name }}" == "pull_request" ]
-          then
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
               _tag=pr-${{ github.event.number }}
+          elif [[ $GITHUB_REF == refs/tags/* ]]; then
+              _tag=${GITHUB_REF#refs/tags/}
           fi
           _full=ldmx/dev:${_tag}
           echo ::set-output name=tag::${_full}
-#    -
-#      name: Build the Image to Local Cache
-#      id: docker_build
-#      uses: docker/build-push-action@v2
-#      with:
-#        push: true
-#        cache-from: ${{ steps.generate_tag.outputs.tag }}
-#        tags: localhost:5000/${{ steps.generate_tag.outputs.tag }}
-#    -
-#      name: Pull down ldmx-sw for testing
-#      uses: actions/checkout@v2
-#      with:
-#        repository: LDMX-Software/ldmx-sw
-#        submodules: recursive
-#    - 
-#      name: Test the Build Image
-#      run: |
-#          export LDMX_BASE=$(pwd)
-#          _image=localhost:5000/${{ steps.generate_tag.outputs.tag }}
-#          mkdir ldmx-sw/build
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build cmake -DBUILD_TESTS=ON ..
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build make install
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . run_test
-#          for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run -i -e LDMX_BASE -v $(pwd):$(pwd) $_image . fire $c; then exit 1; fi; done
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python test.py
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
+    -
+      name: Build the Image to Local Cache
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        cache-from: ${{ steps.generate_tag.outputs.tag }}
+        tags: localhost:5000/${{ steps.generate_tag.outputs.tag }}
+    -
+      name: Pull down ldmx-sw for testing
+      uses: actions/checkout@v2
+      with:
+        repository: LDMX-Software/ldmx-sw
+        submodules: recursive
+    - 
+      name: Test the Build Image
+      run: |
+          export LDMX_BASE=$(pwd)
+          _image=localhost:5000/${{ steps.generate_tag.outputs.tag }}
+          mkdir ldmx-sw/build
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build cmake -DBUILD_TESTS=ON ..
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build make install
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . run_test
+          for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run -i -e LDMX_BASE -v $(pwd):$(pwd) $_image . fire $c; then exit 1; fi; done
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python test.py
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
     -
       name: Login to DockerHub
       uses: docker/login-action@v1
@@ -80,7 +88,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
-#        cache-from: localhost:5000/${{ steps.generate_tag.outputs.tag }}
+        cache-from: localhost:5000/${{ steps.generate_tag.outputs.tag }}
         tags: ${{ steps.generate_tag.outputs.tag }}
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,25 +67,25 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ${{ steps.generate_tag.outputs.tag }}
-#    -
-#      name: Pull down ldmx-sw for testing
-#      uses: actions/checkout@v2
-#      with:
-#        repository: LDMX-Software/ldmx-sw
-#        submodules: recursive
-#        path: ldmx-sw
-#    - 
-#      name: Test the Build Image
-#      run: |
-#          export LDMX_BASE=$(pwd)
-#          _image=${{ steps.generate_tag.outputs.tag }}
-#          mkdir ldmx-sw/build
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build cmake -DBUILD_TESTS=ON ..
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build make install
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . run_test
-#          for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run -i -e LDMX_BASE -v $(pwd):$(pwd) $_image . fire $c; then exit 1; fi; done
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python test.py
-#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
+    -
+      name: Pull down ldmx-sw for testing
+      uses: actions/checkout@v2
+      with:
+        repository: LDMX-Software/ldmx-sw
+        submodules: recursive
+        path: ldmx-sw
+    - 
+      name: Test the Build Image
+      run: |
+          export LDMX_BASE=$(pwd)
+          _image=${{ steps.generate_tag.outputs.tag }}
+          mkdir ldmx-sw/build
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build cmake -DBUILD_TESTS=ON ..
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build make install
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . run_test
+          for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run -i -e LDMX_BASE -v $(pwd):$(pwd) $_image . fire $c; then exit 1; fi; done
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python test.py
+          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
     -
       name: Push Build to DockerHub
       run: docker push ${{ steps.generate_tag.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
     -
       name: Push Build to DockerHub
-      run: docker push ${{ setps.generate_tag.outputs.tag }}
+      run: docker push ${{ steps.generate_tag.outputs.tag }}
 
   # newer version of Geant4
   #     allow for developers to have access to a container with Geant4.10.6 in it

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
   #     this is the container that pretty much everyone in ldmx-sw should use
   basic:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     -
       name: Setup QEMU
@@ -78,14 +81,16 @@ jobs:
       name: Test the Build Image
       run: |
           export LDMX_BASE=$(pwd)
-          _image=${{ steps.generate_tag.outputs.tag }}
+          alias ldmx='docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE ${{ steps.generate_tag.outputs.tag }} $(pwd)'
           mkdir ldmx-sw/build
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build cmake -DBUILD_TESTS=ON ..
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build make install
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . run_test
-          for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run -i -e LDMX_BASE -v $(pwd):$(pwd) $_image . fire $c; then exit 1; fi; done
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python test.py
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
+          cd ldmx-sw/build
+          ldmx cmake -DBUILD_TESTS=ON ..
+          ldmx make install
+          cd ../../
+          ldmx run_test
+          for c in `ls ldmx-sw/*/test/*.py`; do if ! ldmx fire $c; then exit 1; fi; done
+          ldmx python test.py
+          ldmx python3 test.py
     -
       name: Push Build to DockerHub
       run: docker push ${{ steps.generate_tag.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,12 +81,10 @@ jobs:
       name: Test the Build Image
       run: |
           export LDMX_BASE=$(pwd)
-          export _image_to_test="${{ steps.generate_tag.outputs.tag }}"
+          export _image_to_test=${{ steps.generate_tag.outputs.tag }}
           export _docker_parameters="-i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image_to_test"
           mkdir ldmx-sw/build
-          cd ldmx-sw/build
-          docker run $_docker_parameters $(pwd) 'cmake -DBUILD_TESTS=ON .. && make install'
-          cd ../../
+          docker run $_docker_parameters $(pwd)/ldmx-sw/build 'cmake -DBUILD_TESTS=ON .. && make install'
           docker run $_docker_parameters $(pwd) run_test
           for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run $_docker_parameters $(pwd) fire $c; then exit 1; fi; done
           docker run $_docker_parameters $(pwd) python test.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,20 @@
 
 name: Build
 
-# only build if push changes to files involved in the build
 on:
   push:
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
     branches:
-      - main
-    paths: 
-      - 'ldmx.sh' 
-      - 'Dockerfile'
-      - 'install-scripts/**'
-      - '**build.yml'
+      - '**'
+    tags:
+      - 'v*.*'
   pull_request:
-    branches: 
-      - main
-  release:
 
-# the jobs are the different container tags that we want built
+# workflow consists of one building and testing job
 jobs:
-  # basic, defaults development container
-  #     this is the container that pretty much everyone in ldmx-sw should use
-  basic:
+  build-test:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -49,17 +43,36 @@ jobs:
       name: Get Build Context
       uses: actions/checkout@v2
     -
-      name: Determine Image Tag
+      name: Determine Image Tags
       id: generate_tag
       run: |
-          _tag=latest
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-              _tag=pr-${{ github.event.number }}
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-              _tag=${GITHUB_REF#refs/tags/}
+          _repo=ldmx/dev
+          _tag=noop
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            # if pushing a git tag ==> get the git tag for the docker tag
+            _tag=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            # pushing to a branch ==> docker tag is branch name
+            #   if branch name is default_branch, docker tag is 'edge'
+            _tag=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$_tag" ]; then
+              _tag=edge
+            fi
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            # pull request branch ==> docker tag is pr number
+            _tag=pr-${{ github.event.number }}
           fi
-          _full=ldmx/dev:${_tag}
-          echo ::set-output name=tag::${_full}
+          _main_tag="${_repo}:${_tag}"
+          _push_tags="${_main_tag}"
+          if [[ $_tag =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            # latest docker tag is latest version built
+            _push_tags="$_push_tags,${_repo}:latest"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            # on push actions, tag with sha of GITHUB as well
+            _push_tags="$_push_tags,${_repo}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=push_tags::${_push_tags}
+          echo ::set-output name=main_tag::${_main_tag}
     -
       name: Build the Image
       id: docker_build
@@ -69,7 +82,7 @@ jobs:
         load: true # allow image to be availabe to the docker program later in this job
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-        tags: ${{ steps.generate_tag.outputs.tag }}
+        tags: ${{ steps.generate_tag.outputs.push_tags }}
     -
       name: Pull down ldmx-sw for testing
       uses: actions/checkout@v2
@@ -81,7 +94,7 @@ jobs:
       name: Test the Build Image
       run: |
           export LDMX_BASE=$(pwd)
-          export _image_to_test=${{ steps.generate_tag.outputs.tag }}
+          export _image_to_test=${{ steps.generate_tag.outputs.main_tag }}
           export _docker_parameters="-i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image_to_test"
           mkdir ldmx-sw/build
           docker run $_docker_parameters $(pwd)/ldmx-sw/build 'cmake -DBUILD_TESTS=ON .. && make install'
@@ -91,43 +104,4 @@ jobs:
           docker run $_docker_parameters $(pwd) python3 test.py
     -
       name: Push Build to DockerHub
-      run: docker push ${{ steps.generate_tag.outputs.tag }}
-
-  # newer version of Geant4
-  #     allow for developers to have access to a container with Geant4.10.6 in it
-  geant4:
-    runs-on: ubuntu-latest
-    steps:
-    -
-      name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
-    -
-      name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - 
-      name: Cache Docker Layers on GitHub
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx
-    -
-      name: Login to DockerHub
-      uses: docker/login-action@v1
-      if: ${{ github.event_name != 'pull_request' }}
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    - 
-      name: Get Build Context
-      uses: actions/checkout@v2
-    -
-      name: Build and push
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        push: ${{ github.event_name != 'pull_request' }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
-        tags: ldmx/dev:geant4.10.6
-        build-args: GEANT4=geant4-10.6-release
+      run: docker push ${{ steps.generate_tag.outputs.push_tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,16 +81,13 @@ jobs:
       name: Test the Build Image
       run: |
           export LDMX_BASE=$(pwd)
-          alias ldmx='docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE ${{ steps.generate_tag.outputs.tag }} $(pwd)'
+          export ldmx="docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE ${{ steps.generate_tag.outputs.tag }}"
           mkdir ldmx-sw/build
-          cd ldmx-sw/build
-          ldmx cmake -DBUILD_TESTS=ON ..
-          ldmx make install
-          cd ../../
-          ldmx run_test
-          for c in `ls ldmx-sw/*/test/*.py`; do if ! ldmx fire $c; then exit 1; fi; done
-          ldmx python test.py
-          ldmx python3 test.py
+          $ldmx $(pwd)/ldmx-sw/build 'cmake -DBUILD_TESTS=ON .. && make install'
+          $ldmx . run_test
+          for c in `ls ldmx-sw/*/test/*.py`; do if ! $ldmx . fire $c; then exit 1; fi; done
+          $ldmx . python test.py
+          $ldmx . python3 test.py
     -
       name: Push Build to DockerHub
       run: docker push ${{ steps.generate_tag.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,14 +80,15 @@ jobs:
     - 
       name: Test the Build Image
       run: |
-          export LDMX_BASE=$(pwd)
-          export ldmx="docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE ${{ steps.generate_tag.outputs.tag }}"
+          source ldmx-sw/scripts/ldmx-env.sh
           mkdir ldmx-sw/build
-          $ldmx $(pwd)/ldmx-sw/build 'cmake -DBUILD_TESTS=ON .. && make install'
-          $ldmx . run_test
-          for c in `ls ldmx-sw/*/test/*.py`; do if ! $ldmx . fire $c; then exit 1; fi; done
-          $ldmx . python test.py
-          $ldmx . python3 test.py
+          cd ldmx-sw/build
+          ldmx 'cmake -DBUILD_TESTS=ON .. && make install'
+          cd ../../
+          ldmx run_test
+          for c in `ls ldmx-sw/*/test/*.py`; do if ! ldmx fire $c; then exit 1; fi; done
+          ldmx python test.py
+          ldmx python3 test.py
     -
       name: Push Build to DockerHub
       run: docker push ${{ steps.generate_tag.outputs.tag }}
@@ -103,6 +104,13 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+    - 
+      name: Cache Docker Layers on GitHub
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx
     -
       name: Login to DockerHub
       uses: docker/login-action@v1
@@ -119,5 +127,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: ${{ github.event_name != 'pull_request' }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ldmx/dev:geant4.10.6
         build_args: GEANT4=geant4-10.6-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
       with:
         repository: LDMX-Software/ldmx-sw
         submodules: recursive
+        path: ldmx-sw
     - 
       name: Test the Build Image
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       - 'ldmx.sh' 
       - 'Dockerfile'
       - 'install-scripts/**'
-      - '**base.yml'
+      - '**build.yml'
   pull_request:
     branches: 
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,4 +132,4 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ldmx/dev:geant4.10.6
-        build_args: GEANT4=geant4-10.6-release
+        build-args: GEANT4=geant4-10.6-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
     paths-ignore:
       - 'README.md'
       - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
     branches:
       - '**'
     tags:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,5 @@ jobs:
           docker run $_docker_parameters $(pwd) python3 test.py
     -
       name: Push Build to DockerHub
-      #NOTE: this only works because we have a maximum of two docker tags
-      run: _csv_list=${{ steps.generate_tag.outputs.push_tags }}; for tag in ${_csv_list/,/\ }; do docker push $tag; done
+      run: _csv_list=${{ steps.generate_tag.outputs.push_tags }}; for tag in ${_csv_list//,/ }; do docker push $tag; done
       if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,25 +67,25 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ${{ steps.generate_tag.outputs.tag }}
-    -
-      name: Pull down ldmx-sw for testing
-      uses: actions/checkout@v2
-      with:
-        repository: LDMX-Software/ldmx-sw
-        submodules: recursive
-        path: ldmx-sw
-    - 
-      name: Test the Build Image
-      run: |
-          export LDMX_BASE=$(pwd)
-          _image=${{ steps.generate_tag.outputs.tag }}
-          mkdir ldmx-sw/build
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build cmake -DBUILD_TESTS=ON ..
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build make install
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . run_test
-          for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run -i -e LDMX_BASE -v $(pwd):$(pwd) $_image . fire $c; then exit 1; fi; done
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python test.py
-          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
+#    -
+#      name: Pull down ldmx-sw for testing
+#      uses: actions/checkout@v2
+#      with:
+#        repository: LDMX-Software/ldmx-sw
+#        submodules: recursive
+#        path: ldmx-sw
+#    - 
+#      name: Test the Build Image
+#      run: |
+#          export LDMX_BASE=$(pwd)
+#          _image=${{ steps.generate_tag.outputs.tag }}
+#          mkdir ldmx-sw/build
+#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build cmake -DBUILD_TESTS=ON ..
+#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build make install
+#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . run_test
+#          for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run -i -e LDMX_BASE -v $(pwd):$(pwd) $_image . fire $c; then exit 1; fi; done
+#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python test.py
+#          docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
     -
       name: Push Build to DockerHub
       run: docker push ${{ steps.generate_tag.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,15 +80,17 @@ jobs:
     - 
       name: Test the Build Image
       run: |
-          source ldmx-sw/scripts/ldmx-env.sh
+          export LDMX_BASE=$(pwd)
+          export _image_to_test="${{ steps.generate_tag.outputs.tag }}"
+          export _docker_parameters="-i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image_to_test"
           mkdir ldmx-sw/build
           cd ldmx-sw/build
-          ldmx 'cmake -DBUILD_TESTS=ON .. && make install'
+          docker run $_docker_parameters $(pwd) 'cmake -DBUILD_TESTS=ON .. && make install'
           cd ../../
-          ldmx run_test
-          for c in `ls ldmx-sw/*/test/*.py`; do if ! ldmx fire $c; then exit 1; fi; done
-          ldmx python test.py
-          ldmx python3 test.py
+          docker run $_docker_parameters $(pwd) run_test
+          for c in `ls ldmx-sw/*/test/*.py`; do if ! docker run $_docker_parameters $(pwd) fire $c; then exit 1; fi; done
+          docker run $_docker_parameters $(pwd) python test.py
+          docker run $_docker_parameters $(pwd) python3 test.py
     -
       name: Push Build to DockerHub
       run: docker push ${{ steps.generate_tag.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,5 +109,6 @@ jobs:
           docker run $_docker_parameters $(pwd) python3 test.py
     -
       name: Push Build to DockerHub
-      run: docker push ${{ steps.generate_tag.outputs.push_tags }}
+      #NOTE: this only works because we have a maximum of two docker tags
+      run: _csv_list=${{ steps.generate_tag.outputs.push_tags }}; for tag in ${_csv_list/,/\ }; do docker push $tag; done
       if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,13 +64,14 @@ jobs:
           fi
           _main_tag="${_repo}:${_tag}"
           _push_tags="${_main_tag}"
-          if [[ $_tag =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            # latest docker tag is latest version built
+          if [[ $_tag =~ ^v[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            # latest docker tag is latest version built matching the format v<1-3 digis>.<1-3 digis>
             _push_tags="$_push_tags,${_repo}:latest"
           elif [ "${{ github.event_name }}" = "push" ]; then
             # on push actions, tag with sha of GITHUB as well
             _push_tags="$_push_tags,${_repo}:sha-${GITHUB_SHA::8}"
           fi
+          echo "Generated Tags: ${_push_tags}"
           echo ::set-output name=push_tags::${_push_tags}
           echo ::set-output name=main_tag::${_main_tag}
     -
@@ -105,3 +106,4 @@ jobs:
     -
       name: Push Build to DockerHub
       run: docker push ${{ steps.generate_tag.outputs.push_tags }}
+      if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,6 @@ jobs:
   #     this is the container that pretty much everyone in ldmx-sw should use
   basic:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     steps:
     -
       name: Setup QEMU
@@ -34,8 +29,19 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+    - 
+      name: Cache Docker Layers on GitHub
+      uses: actions/cache@v2
       with:
-        driver-opts: network=host
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx
+    -
+      name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
     - 
       name: Get Build Context
       uses: actions/checkout@v2
@@ -52,13 +58,15 @@ jobs:
           _full=ldmx/dev:${_tag}
           echo ::set-output name=tag::${_full}
     -
-      name: Build the Image to Local Cache
+      name: Build the Image
       id: docker_build
       uses: docker/build-push-action@v2
       with:
-        push: true
-        cache-from: ${{ steps.generate_tag.outputs.tag }}
-        tags: localhost:5000/${{ steps.generate_tag.outputs.tag }}
+        push: false # don't push to docker hub yet
+        load: true # allow image to be availabe to the docker program later in this job
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
+        tags: ${{ steps.generate_tag.outputs.tag }}
     -
       name: Pull down ldmx-sw for testing
       uses: actions/checkout@v2
@@ -69,7 +77,7 @@ jobs:
       name: Test the Build Image
       run: |
           export LDMX_BASE=$(pwd)
-          _image=localhost:5000/${{ steps.generate_tag.outputs.tag }}
+          _image=${{ steps.generate_tag.outputs.tag }}
           mkdir ldmx-sw/build
           docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build cmake -DBUILD_TESTS=ON ..
           docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image ldmx-sw/build make install
@@ -78,19 +86,8 @@ jobs:
           docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python test.py
           docker run -i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image . python3 test.py
     -
-      name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    -
       name: Push Build to DockerHub
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        cache-from: localhost:5000/${{ steps.generate_tag.outputs.tag }}
-        tags: ${{ steps.generate_tag.outputs.tag }}
-
+      run: docker push ${{ setps.generate_tag.outputs.tag }}
 
   # newer version of Geant4
   #     allow for developers to have access to a container with Geant4.10.6 in it

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ MAINTAINER Tom Eichlersmith <eichl008@umn.edu>
 #   Dep              | Reason
 #   wget             | install xerces and download Conditions tables
 #   git              | download ROOT and Geant4 source
-#   dpkg-dev         | 
+#   dpkg-dev         | ROOT external dependency for compression algorithms
 #   python-dev       | ROOT interface with python2
 #   python-pip       | install extra python2 packages
 #   python-numpy     | extra python2 package numpy
@@ -40,7 +40,7 @@ MAINTAINER Tom Eichlersmith <eichl008@umn.edu>
 #   make             | Build tool for compiling source code
 #   g++-7            | Compiler with C++17 support
 #   gcc-7            | Compiler with C++17 support
-#   binutils         |
+#   binutils         | ROOT external dependency for compression algorithms
 #   libx11-dev       | ROOT external dependency for accessing screen
 #   libxpm-dev       | ROOT external dependency for accessing screen
 #   libxft-dev       | ROOT external dependency for accessing screen


### PR DESCRIPTION
This has no changes to the container; I am only updating the workflow action to provide a few helpful features. This PR resolves #29 .

- Caching image layers with GitHub so future builds that only change later layers can be built faster
- Testing the build before pushing it to DockerHub by pulling down ldmx-sw