### PR TITLE
Request compilation of OpenGL-dependent libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,6 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - 
-      name: Cache Docker Layers on GitHub
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx
     -
       name: Login to DockerHub
       uses: docker/login-action@v1
@@ -84,8 +77,6 @@ jobs:
       with:
         push: false # don't push to docker hub yet
         load: true # allow image to be availabe to the docker program later in this job
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ${{ steps.generate_tag.outputs.push_tags }}
     -
       name: Determine ldmx-sw Branch to Test
@@ -112,7 +103,7 @@ jobs:
           export _image_to_test=${{ steps.generate_tag.outputs.main_tag }}
           export _docker_parameters="-i -e LDMX_BASE -v $LDMX_BASE:$LDMX_BASE $_image_to_test"
           mkdir ldmx-sw/build
-          docker run $_docker_parameters $(pwd)/ldmx-sw/build 'cmake -DBUILD_TESTS=ON .. && make install'
+          docker run $_docker_parameters $(pwd)/ldmx-sw/build 'cmake .. && make install'
           docker run $_docker_parameters $(pwd) ctest --verbose
           docker run $_docker_parameters $(pwd) python test.py
           docker run $_docker_parameters $(pwd) python3 test.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ on:
       - '**'
     tags:
       - 'v*.*'
-  pull_request:
 
 # workflow consists of one building and testing job
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update &&\
         gcc-7 \
         git \
         libafterimage-dev \
+        libboost-all-dev \
         libcfitsio-dev \
         libfcgi-dev \
         libfftw3-dev \
@@ -155,29 +156,6 @@ RUN _geant4_remote="https://gitlab.cern.ch/geant4/geant4.git" &&\
         --target install \
     &&\
     cd .. && rm -rf geant4
-
-###############################################################################
-# Install Boost into the container
-#
-# TODO: THe boost installed from this PPA seems to work with everything,
-#       but cmake complains with piles of warnings.
-# 
-# Assumptions
-#  - BOOST version of boost release available at the referenced PPA
-###############################################################################
-ARG BOOST=1.74
-LABEL boost.version="${BOOST}"
-RUN apt-get update &&\
-    apt-get install -y \
-        software-properties-common \
-    &&\
-    add-apt-repository ppa:mhier/libboost-latest &&\
-    apt-get update &&\
-    apt-get install -y libboost${BOOST}-dev &&\
-    apt-get purge -y \
-        software-properties-common \
-    &&\
-    apt-get autoremove -y
 
 ###############################################################################
 # Extra python packages for analysis

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN _geant4_remote="https://gitlab.cern.ch/geant4/geant4.git" &&\
         _geant4_remote="https://github.com/LDMX-Software/geant4.git"; \
     fi &&\
     git clone -b ${GEANT4} --single-branch ${_geant4_remote} &&\
-    mkdir geant4/build &&\
+    cd geant4 &&\
     cmake \
         -DGEANT4_INSTALL_DATA=ON \
         -DGEANT4_USE_GDML=ON \
@@ -147,14 +147,14 @@ RUN _geant4_remote="https://gitlab.cern.ch/geant4/geant4.git" &&\
         -DGEANT4_USE_OPENGL_X11=ON \
         -DXERCESC_ROOT_DIR=$XercesC_DIR \
         -DCMAKE_INSTALL_PREFIX=$G4DIR \
-        -B geant4/build \
-        -S geant4 \
+        -B build \
+        -S . \
         &&\
     cmake \
-        --build geant4/build \
+        --build build \
         --target install \
     &&\
-    rm -rf geant4
+    cd .. && rm -rf geant4
 
 ###############################################################################
 # Install Boost into the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN mkdir cernroot &&\
         -Dxrootd=OFF \
         -DCMAKE_CXX_STANDARD=17 \
         -Dminimal=${MINIMAL} \
+        -Dopengl=ON \
         -DCMAKE_INSTALL_PREFIX=$ROOTSYS \
         -B /cernroot/build \
         -S /cernroot/root \
@@ -143,6 +144,7 @@ RUN _geant4_remote="https://gitlab.cern.ch/geant4/geant4.git" &&\
         -DGEANT4_INSTALL_DATA=ON \
         -DGEANT4_USE_GDML=ON \
         -DGEANT4_INSTALL_EXAMPLES=OFF \
+        -DGEANT4_USE_OPENGL_X11=ON \
         -DXERCESC_ROOT_DIR=$XercesC_DIR \
         -DCMAKE_INSTALL_PREFIX=$G4DIR \
         -B geant4/build \

--- a/docs/ubuntu-packages.md
+++ b/docs/ubuntu-packages.md
@@ -1,62 +1,62 @@
 # Ubuntu Packages
 Here I try to list all of the installed ubuntu packages and give an explanation of why they are included.
-Lot's of these packages are installed into the [ROOT official docker container](https://github.com/root-project/root-docker/blob/master/ubuntu/Dockerfile) and so I have copied them here. I don't know what their purpose is or if they are necessary or even helpful.
+Lot's of these packages are installed into the [ROOT official docker container](https://github.com/root-project/root-docker/blob/master/ubuntu/Dockerfile) and so I have copied them here. I have looked into their purpose by a combination of googling the package name and looking at [ROOT's reason for them](https://root.cern/install/dependencies/). 
 
-Package | Reason
----|---
-binutils |
-ca-certificates | Installing certificates to trust in container
-davix-dev |
-dcap-dev |
-dpkg-dev |
-fonts-freefont-ttf |
-g++-7 | Compiler with C++17 support
-gcc-7 | Compiler with C++17 support
-git | Downloading dependency sources
-libafterimage-dev |
-libcfitsio-dev |
-libfcgi-dev |
-libfftw3-dev |
-libfreetype6-dev |
-libftgl-dev |
-libgfal2-dev |
-libgif-dev |
-libgl1-mesa-dev |
-libgl2ps-dev |
-libglew-dev |
-libglu-dev |
-libgraphviz-dev |
-libgsl-dev |
-libjpeg-dev |
-liblz4-dev |
-liblzma-dev |
-libmysqlclient-dev |
-libpcre++-dev |
-libpng-dev |
-libpq-dev |
-libpythia8-dev |
-libsqlite3-dev |
-libssl-dev |
-libtbb-dev |
-libtiff-dev |
-libx11-dev |
-libxext-dev |  
-libxft-dev |
-libxml2-dev |
-libxmu-dev |
-libxpm-dev |
-libz-dev |
-libzstd-dev |
-locales | Configuration of TPython and other python packages
-make | Building dependencies and ldmx-sw source
-python-dev | ROOT TPython
-python-pip | For downloading more python packages later
-python-numpy | ROOT TPython requires numpty
-python-tk | matplotlib requires python-tk for some plotting
-python3-dev | ROOT TPython and ldmx-sw ConfigurePython
-python3-pip | For downloading more python packages later
-python3-numpy | ROOT TPython requires numpy
-python3-tk | matplotlib requires python-tk for some plotting
-srm-ifce-dev |
-unixodbc-dev | 
-wget | Download Xerces-C source and dowload Conditions tables in ldmx-sw
+Package | Necessary | Reason
+---|---|---
+binutils | Yes | Adding PPA and linking libraries
+ca-certificates | Yes | Installing certificates to trust in container
+davix-dev | No | Remote I/O, file transfer and file management
+dcap-dev | Unknown | C-API to the [DCache Access Protocol](https://dcache.org/old/manuals/libdcap.shtml)
+dpkg-dev | Yes | Installation from PPA
+fonts-freefont-ttf | Yes | Fonts for plots
+g++-7 | Yes | Compiler with C++17 support
+gcc-7 | Yes | Compiler with C++17 support
+git | Yes | Downloading dependency sources
+libafterimage-dev | Unknown | Unknown
+libcfitsio-dev | No | Reading and writing in [FITS](https://heasarc.gsfc.nasa.gov/docs/heasarc/fits.html) data format
+libfcgi-dev | No | Open extension of CGI for internet applications
+libfftw3-dev | Yes | Computing discrete fourier transform
+libfreetype6-dev | Yes | Fonts for plots
+libftgl-dev | Yes | Rendering fonts in OpenGL
+libgfal2-dev | No | Toolkit for file management across different protocols
+libgif-dev | Yes | Saving plots as GIFs
+libgl1-mesa-dev | Yes | [MesaGL](https://mesa3d.org/) allowing 3D rendering using OpenGL
+libgl2ps-dev | Yes | Convert OpenGL image to PostScript file
+libglew-dev | Yes | [GLEW](http://glew.sourceforge.net/) library for helping use OpenGL
+libglu-dev | Yes | [OpenGL Utility Library](https://www.opengl.org/resources/libraries/)
+libgraphviz-dev | No | Graph visualization library
+libgsl-dev | No | GNU Scientific library for numerical calculations
+libjpeg-dev | Yes | Saving plots as JPEGs
+liblz4-dev | Yes | Data compression
+liblzma-dev | Yes | Data compression
+libmysqlclient-dev | No | Interact with SQL database
+libpcre++-dev | Yes | Regular expression pattern matching
+libpng-dev | Yes | Saving plots as PNGs
+libpq-dev | No | Light binaries and headers for PostgreSQL applications
+libpythia8-dev | No | [Pythia8](http://home.thep.lu.se/~torbjorn/pythia81html/Welcome.html) HEP simulation
+libsqlite3-dev | No | Interact with SQL database
+libssl-dev | Yes | Securely interact with other computers and encrypt files
+libtbb-dev | No | Multi-threading
+libtiff-dev | No | Save plots as TIFF image files
+libx11-dev | Yes | Low-level window management with X11
+libxext-dev | Yes | Low-level window management
+libxft-dev | Yes | Low-level window management
+libxml2-dev | Yes | Low-level window management
+libxmu-dev | Yes | Low-level window management
+libxpm-dev | Yes | Low-level window management
+libz-dev | Yes | Data compression
+libzstd-dev | Yes | Data compression
+locales | Yes | Configuration of TPython and other python packages
+make | Yes | Building dependencies and ldmx-sw source
+python-dev | Yes | ROOT TPython
+python-pip | Yes | For downloading more python packages later
+python-numpy | Yes | ROOT TPython requires numpty
+python-tk | Yes | matplotlib requires python-tk for some plotting
+python3-dev | Yes | ROOT TPython and ldmx-sw ConfigurePython
+python3-pip | Yes | For downloading more python packages later
+python3-numpy | Yes | ROOT TPython requires numpy
+python3-tk | Yes | matplotlib requires python-tk for some plotting
+srm-ifce-dev | Unknown | Unknown
+unixodbc-dev | No | Access different data sources uniformly
+wget | Yes | Download Xerces-C source and dowload Conditions tables in ldmx-sw

--- a/ldmx.sh
+++ b/ldmx.sh
@@ -48,7 +48,7 @@ do
 done
 
 # helps simplify any cmake nonsense
-export CMAKE_PREFIX_PATH=$XercesC_DIR:$ROOTSYS:$G4DIR:$Eigen_DIR:$LDMX_SW_INSTALL
+export CMAKE_PREFIX_PATH=$XercesC_DIR:$ROOTSYS:$G4DIR:$LDMX_SW_INSTALL
 
 # puts a config/cache directory for matplotlib to use
 export MPLCONFIGDIR=$LDMX_BASE/.config/matplotlib


### PR DESCRIPTION
I have added the necessary Ubuntu packages and cmake parameters so that the parts of ROOT and Geant4 that are dependent on OpenGL are compiled. This enables us to compile programs that use ROOT and Geant4's OpenGL-dependent libraries inside of this container.

Still lots of testing to do, but it seems like we are getting close to another major release of the container.

