### PR TITLE
GDB and sanitizer support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update &&\
         fonts-freefont-ttf \
         g++-7 \
         gcc-7 \
-	gdb \
-	libasan4-dbg \
+        gdb \
+        libasan4-dbg \
         libafterimage-dev \
         libfftw3-dev \
         libfreetype6-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update &&\
         fonts-freefont-ttf \
         g++-7 \
         gcc-7 \
+	gdb \
+	libasan4-dbg \
         libafterimage-dev \
         libfftw3-dev \
         libfreetype6-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update &&\
         g++-7 \
         gcc-7 \
         gdb \
-        libasan4-dbg \
         libafterimage-dev \
+        libasan4-dbg \
         libfftw3-dev \
         libfreetype6-dev \
         libftgl-dev \

--- a/docs/ubuntu-packages.md
+++ b/docs/ubuntu-packages.md
@@ -13,8 +13,10 @@ dpkg-dev | No | **Old** Installation from PPA
 fonts-freefont-ttf | Yes | Fonts for plots
 g++-7 | Yes | Compiler with C++17 support
 gcc-7 | Yes | Compiler with C++17 support
+gdb | No | Supporting debugging LDMX-sw programs within the container
 git | No | **Old** Downloading dependency sources
 libafterimage-dev | Yes | ROOT GUI depends on these for common shapes
+libasan4-dbg | No | Runtime components for the compiler based instrumentation tools that come with GCC
 libcfitsio-dev | No | Reading and writing in [FITS](https://heasarc.gsfc.nasa.gov/docs/heasarc/fits.html) data format
 libfcgi-dev | No | Open extension of CGI for internet applications
 libfftw3-dev | Yes | Computing discrete fourier transform


### PR DESCRIPTION
I am adding a new package to the container, here are the details.

### What new packages does this PR add to the development container?
- GDB, the standard debugger on Linux machines. Package: gdb
- Runtime components for the sanitizer tools. Package: libasan4-dbg

## Check List
- [x] I successfully built the container using docker
```
# outline of container build instructions
cd docker
git checkout my-updates
docker build . -t ldmx/local:temp-tag
```
- [x] I was able to build ldmx-sw using this new container build
Note: the -DBUILD_TEST=ON flag doesn't do anything. However, I could still run the test suite with ldmx make test. 3 tests in Packing failed. 
```
# outline of build instructions
ldmx-container-pull local temp-tag
cd ldmx-sw
mkdir build
cd build
ldmx cmake -DBUILD_TESTS=ON ..
ldmx make install
```
- [x] I was able to test run a small simulation and reconstruction inside this container
```
# outline of test instructions
cd $LDMX_BASE
ldmx run_test
for c in `ls ldmx-sw/*/test/*.py`; ldmx fire $c; done
```
- [x] I was able to successfully use the new packages. Explain what you did to test them below:
For GDB: run `ldmx gdb` 
For sanitizers, run `ldmx g++ -fsanitize=address test.cxx -o test && ldmx ./test` on a file like 
```c++
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
int main(int argc, const char *argv[]) {
    char *s = malloc(100);
    free(s);
    strcpy(s, "Hello world!");
    printf("string is: %s\n", s);
    return 0;
}
```
