### PR TITLE
delete acts from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,33 +207,3 @@ RUN mkdir src &&\
     &&\
     ln -s ${__prefix}/bin/thisdd4hep.sh ${__ldmx_env_script_d__}/thisdd4hep.sh &&\
     rm -r src
-
-###############################################################################
-# Install ACTS Common Tracking Software into the container
-#
-# Assumptions
-#  - Dependencies installed to ${__prefix}
-#  - ACTS set to release name of GitHub repository
-###############################################################################
-ENV ACTS=v14.1.0
-LABEL acts.version="${ACTS}"
-RUN mkdir src &&\
-    ${__wget} https://github.com/acts-project/acts/archive/refs/tags/${ACTS}.tar.gz |\
-      ${__untar} &&\
-    export DD4hep_DIR=${__prefix} &&\
-    export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/root &&\
-    cmake \
-        -DACTS_BUILD_EXAMPLES=OFF \
-        -DCMAKE_INSTALL_PREFIX=${__prefix} \
-        -DCMAKE_CXX_STANDARD=17 \
-        -DACTS_BUILD_PLUGIN_DD4HEP=ON \
-        -B src/build \
-        -S src \
-    &&\
-    cmake \
-        --build src/build \
-        --target install \
-    &&\
-    ln -s ${__prefix}/bin/this_acts.sh ${__ldmx_env_script_d__}/this_acts.sh &&\
-    rm -rf src
-

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Direct Dependecy of ldmx-sw | Version | Construction Process
 [Geant4](https://geant4.web.cern.ch/node/1) | [LDMX.10.2.3\_v0.4](https://github.com/LDMX-Software/geant4/tree/LDMX.10.2.3_v0.4) | Built from source
 [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) | 3.4.0 | Built from source
 [DD4hep](https://github.com/AIDASoft/DD4hep) | 01-18 | Built from source
-[ACTS](https://github.com/acts-project/acts) | 14.1.0 | Built from source
 
 A detailed list of all packages installed from ubuntu repositories is given [here](docs/ubuntu-packages.md).
 


### PR DESCRIPTION
acts development is moving too fast at the moment and our tracking development needs to keep up, so it is easier to build it downstream within ldmx-sw instead of pre-building it into the development image.

This resolves #42 