### PR TITLE
Iss41 boost python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,8 @@ RUN mkdir src &&\
     ${__wget} https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz |\
       ${__untar} &&\
     cd src &&\
+    # Configure Boost.Python to look for the Python version we have.
+    sed -i 's/using python ;/using python : 3.6 ;/' libs/python/build/Jamfile &&\
     ./bootstrap.sh &&\
     ./b2 install &&\
     cd .. && rm -rf src

--- a/entry.sh
+++ b/entry.sh
@@ -36,7 +36,7 @@ if [ -z "${LDMX_SW_INSTALL}" ]; then
   export LDMX_SW_INSTALL=$LDMX_BASE/ldmx-sw/install
 fi
 export LD_LIBRARY_PATH=$LDMX_SW_INSTALL/lib:$LD_LIBRARY_PATH
-export PYTHONPATH=$LDMX_SW_INSTALL/python:$PYTHONPATH
+export PYTHONPATH=$LDMX_SW_INSTALL/python:$LDMX_SW_INSTALL/libn:$PYTHONPATH
 export PATH=$LDMX_SW_INSTALL/bin:$PATH
 
 # add externals installed along side ldmx-sw

--- a/entry.sh
+++ b/entry.sh
@@ -36,7 +36,7 @@ if [ -z "${LDMX_SW_INSTALL}" ]; then
   export LDMX_SW_INSTALL=$LDMX_BASE/ldmx-sw/install
 fi
 export LD_LIBRARY_PATH=$LDMX_SW_INSTALL/lib:$LD_LIBRARY_PATH
-export PYTHONPATH=$LDMX_SW_INSTALL/python:$LDMX_SW_INSTALL/libn:$PYTHONPATH
+export PYTHONPATH=$LDMX_SW_INSTALL/python:$LDMX_SW_INSTALL/lib:$PYTHONPATH
 export PATH=$LDMX_SW_INSTALL/bin:$PATH
 
 # add externals installed along side ldmx-sw


### PR DESCRIPTION
I am adding a new package to the container, here are the details.

### What new packages does this PR add to the development container?
This doesn't actually add any package, but fixes the configuration for Boost that we were using to try and build Boost.Python. It also adds $LDMX_SW_INSTALL/lib to the PYTHONPATH variable to make any shared objects that are built with Boost.Python accessible from within the container environment. 

For details see https://github.com/LDMX-Software/ldmx-sw/issues/1048 and corresponding upcoming PRs
## Check List
- [x] I successfully built the container using docker
- [x] I was able to build ldmx-sw using this new container build
- [x] I was able to test run a small simulation and reconstruction inside this container
- [x] I was able to successfully use the new packages. Explain what you did to test them below:

We have at least one student that has been successfully using this together with https://github.com/LDMX-Software/ldmx-sw/issues/1048 to decode DetectorIDs in their analysis 