### PR TITLE
bump versions of actions used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
     -
       name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - 
       name: Get Build Context
       uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
     -
       name: Download Image
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ldmx-dev-${{ github.sha }}
     - 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
       uses: docker/setup-buildx-action@v1
     - 
       name: Get Build Context
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     -
       name: Build the Image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: false # don't push to docker hub yet
         load: true # allow image to be availabe to the docker program later in this job
@@ -44,7 +44,7 @@ jobs:
       run: docker save new-build > ldmx-dev.tar
     - 
       name: Upload Newly Built Image
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ldmx-dev-${{ github.sha }}
         path: ldmx-dev.tar
@@ -61,10 +61,10 @@ jobs:
     steps:
     -
       name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     -
       name: Download Image
       uses: actions/download-artifact@v2
@@ -75,10 +75,10 @@ jobs:
       run: docker load --input ldmx-dev.tar
     -
       name: Download Build Context for Test Script
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     -
       name: Pull down ldmx-sw for testing
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: LDMX-Software/ldmx-sw
         submodules: recursive
@@ -109,13 +109,13 @@ jobs:
     steps:
     -
       name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     -
       name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -151,7 +151,7 @@ jobs:
           echo ::set-output name=push_tags::${_push_tags}
     -
       name: Download Image
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ldmx-dev-${{ github.sha }}
     - 


### PR DESCRIPTION
due to GitHub deprecations, we need to update the versions of the actions we are using.

This will have the side benefit of caching image layers during builds as well.