### PR TITLE
66 somethings wrong with the dockerhub setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,15 +63,15 @@ jobs:
       -
         name: Export digest
         run: |
-          mkdir -p /tmp/digests
+          mkdir digest
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "digest/${digest#sha256:}"
       -
         name: Upload digest
         uses: actions/upload-artifact@v3
         with:
-          name: digests
-          path: /tmp/digests/*
+          name: ${{matrix.platform}}-digest
+          path: digest/*
           if-no-files-found: error
 
   merge:
@@ -83,8 +83,7 @@ jobs:
         name: Download digests
         uses: actions/download-artifact@v3
         with:
-          name: digests
-          path: /tmp/digests
+          path: digests
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -107,10 +106,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Create manifest list and push
-        working-directory: /tmp/digests
+        working-directory: digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' */*)
       -
         name: Inspect image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,16 +62,22 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       -
         name: Export digest
+        id: export-digest
         run: |
           mkdir digest
           digest="${{ steps.build.outputs.digest }}"
-          touch "digest/${digest#sha256:}"
+          platform="${{ matrix.platform }}"
+          digest_name="${platform#linux/}-digest"
+          digest_file="digest/${digest#sha256:}"
+          touch "${digest_file}"
+          echo "name=${digest_name}" >> "$GITHUB_OUTPUT"
+          echo "file=${digest_file}" >> "$GITHUB_OUTPUT"
       -
         name: Upload digest
         uses: actions/upload-artifact@v3
         with:
-          name: ${{matrix.platform}}-digest
-          path: digest/*
+          name: ${{ steps.export-digest.outputs.name }}
+          path: ${{ steps.export-digest.outputs.file }}
           if-no-files-found: error
 
   merge:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         working-directory: digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' */*)
+            $(find -type f -exec basename {} ';' | xargs printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ')
       -
         name: Inspect image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,18 @@ jobs:
         with:
           context: .
           cache-from: type=local,src=/home/github/layer-cache/${{matrix.platform}}
-          cache-to: type=local,dest=/home/github/layer-cache/${{matrix.platform}},mode=max
+          cache-to: type=local,dest=/home/github/layer-cache/${{matrix.platform}}-new,mode=max
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /home/github/layer-cache/${{matrix.platform}}
+          mv /home/github/layer-cache/${{matrix.platform}}-new /home/github/layer-cache/${{matrix.platform}}  
       -
         name: Export digest
         id: export-digest


### PR DESCRIPTION
I am patching the GitHub workflow to actually only merge the two digests from that workflow run instead of all previous digests.

Also, the builder already had filled up the disk allocated to its layer cache and so I am following the online instructions of replacing the old cache with the newly-generated cache so that a repeated build only updates the cache timestamp instead of adding to the cache.