### PR TITLE
Docker labels derived from env variables set once per dependency 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,9 +190,10 @@ RUN install-ubuntu-packages \
     srm-ifce-dev \
     libgsl-dev # Necessary for GENIE
 
-LABEL root.version="6.22.08"
+ROOT_VERSION="6.22.08"
+LABEL root.version=${ROOT_VERSION}
 RUN mkdir src &&\
-    ${__wget} https://root.cern/download/root_v6.22.08.source.tar.gz |\
+    ${__wget} https://root.cern/download/root_v${ROOT_VERSION}.source.tar.gz |\
      ${__untar} &&\
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -296,9 +297,10 @@ RUN mkdir src &&\
 # - We disable the python subpackage because it is based on Python2 whose
 #   executable has been removed from Ubuntu 22.04.
 ###############################################################################
-LABEL lhapdf.version="6.5.3"
+LHAPDF_VERSION="6.5.3"
+LABEL lhapdf.version=${LHAPDF_VERSION}
 RUN mkdir src &&\
-    ${__wget} https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.5.3.tar.gz |\
+    ${__wget} https://lhapdf.hepforge.org/downloads/?f=LHAPDF-${LHAPDF_VERSION}.tar.gz |\
       ${__untar} &&\
     cd src &&\
     ./configure --disable-python --prefix=${__prefix} &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -340,11 +340,11 @@ RUN install-ubuntu-packages \
     libtool
 
 
-LABEL genie.version=3.02.00
 ENV GENIE_VERSION=3_02_00
 #ENV GENIE_REWEIGHT_VERSION=1_02_00
-
 ENV GENIE=/usr/local/src/GENIE/Generator
+LABEL genie.version=$(sed -e 's/_/\./g' <<< $GENIE_VERSION )
+
 
 RUN mkdir -p ${GENIE} &&\
     ${__wget} https://github.com/GENIE-MC/Generator/archive/refs/tags/R-${GENIE_VERSION}.tar.gz |\
@@ -365,9 +365,10 @@ RUN mkdir -p ${GENIE} &&\
 ###############################################################################
 # Catch2
 ###############################################################################
-LABEL catch2.version=3.3.1
+CATCH2_VERSION=3.3.1
+LABEL catch2.version=${CATCH2_VERSION}
 RUN mkdir -p src &&\
-    ${__wget} https://github.com/catchorg/Catch2/archive/refs/tags/v3.3.1.tar.gz |\
+    ${__wget} https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VERSION}.tar.gz |\
       ${__untar} &&\
     cmake -B src/build -S src &&\
     cmake --build src/build --target install -- -j$NPROC &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ ENV CMAKE_PREFIX_PATH="${EXTERNAL_INSTALL_DIR}:${__prefix}"
 # Xerces-C 
 #   Used by Geant4 to parse GDML
 ################################################################################
-XERCESC_VERSION="3.2.4"
+ENV XERCESC_VERSION="3.2.4"
 LABEL xercesc.version=${XERCESC_VERSION}
 #LABEL xercesc.version="3.2.4"
 RUN mkdir src &&\
@@ -114,14 +114,14 @@ RUN mkdir src &&\
 # (Ideally GENIE works with Pythia8? But not sure that works yet despite the adverts that it does.)
 # 
 ###############################################################################
-PYTHIA_VERSION="6.428"
-PREVIOUS_PYTHIA_VERSION="6.416"
+ENV PYTHIA_VERSION="6.428"
+ENV PREVIOUS_PYTHIA_VERSION="6.416"
 LABEL pythia.version=${PYTHIA_VERSION}
 #"6.428"
 # Pythia uses an un-dotted version file naming convention
-PYTHIA_VERSION_INTEGER=$(awk '{print $1*1000}' <<< "${PYTHIA_VERSION}" )
-PREVIOUS_PYTHIA_VERSION_INTEGER=$(awk '{print $1*1000}' <<< "${PREVIOUS_PYTHIA_VERSION}" )
-PYTHIA_MAJOR_VERSION=$(awk '{print int($1) }' <<< "${PYTHIA_VERSION}" )
+ENV PYTHIA_VERSION_INTEGER=$(awk '{print $1*1000}' <<< "${PYTHIA_VERSION}" )
+ENV PREVIOUS_PYTHIA_VERSION_INTEGER=$(awk '{print $1*1000}' <<< "${PREVIOUS_PYTHIA_VERSION}" )
+ENV PYTHIA_MAJOR_VERSION=$(awk '{print int($1) }' <<< "${PYTHIA_VERSION}" )
 
 RUN mkdir src && \
     ${__wget} https://root.cern.ch/download/pythia${PYTHIA_MAJOR_VERSION}.tar.gz | ${__untar} &&\
@@ -190,7 +190,7 @@ RUN install-ubuntu-packages \
     srm-ifce-dev \
     libgsl-dev # Necessary for GENIE
 
-ROOT_VERSION="6.22.08"
+ENV ROOT_VERSION="6.22.08"
 LABEL root.version=${ROOT_VERSION}
 RUN mkdir src &&\
     ${__wget} https://root.cern/download/root_v${ROOT_VERSION}.source.tar.gz |\
@@ -297,7 +297,7 @@ RUN mkdir src &&\
 # - We disable the python subpackage because it is based on Python2 whose
 #   executable has been removed from Ubuntu 22.04.
 ###############################################################################
-LHAPDF_VERSION="6.5.3"
+ENV LHAPDF_VERSION="6.5.3"
 LABEL lhapdf.version=${LHAPDF_VERSION}
 RUN mkdir src &&\
     ${__wget} https://lhapdf.hepforge.org/downloads/?f=LHAPDF-${LHAPDF_VERSION}.tar.gz |\
@@ -343,7 +343,8 @@ RUN install-ubuntu-packages \
 ENV GENIE_VERSION=3_02_00
 #ENV GENIE_REWEIGHT_VERSION=1_02_00
 ENV GENIE=/usr/local/src/GENIE/Generator
-LABEL genie.version=$(sed -e 's/_/\./g' <<< $GENIE_VERSION )
+ENV GENIE_DOT_VERSION=$(sed 's,_,\.,g' <<< $GENIE_VERSION )
+LABEL genie.version=${GENIE_DOT_VERSION}
 
 
 RUN mkdir -p ${GENIE} &&\
@@ -365,7 +366,7 @@ RUN mkdir -p ${GENIE} &&\
 ###############################################################################
 # Catch2
 ###############################################################################
-CATCH2_VERSION="3.3.1"
+ENV CATCH2_VERSION="3.3.1"
 LABEL catch2.version=${CATCH2_VERSION}
 RUN mkdir -p src &&\
     ${__wget} https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VERSION}.tar.gz |\
@@ -386,7 +387,7 @@ RUN mkdir -p src &&\
 #  so I don't think it will be able to be used in arm architecture images.
 #  For this reason, I am omitting it until future development is done.
 ###############################################################################
-ONNX_VERSION="1.15.0"
+ENV ONNX_VERSION="1.15.0"
 LABEL onnx.version=${ONNX_VERSION}
 #RUN mkdir -p src &&\
 #    ${__wget} https://github.com/microsoft/onnxruntime/archive/refs/tags/v${ONNX_VERSION}.tar.gz |\

--- a/Dockerfile
+++ b/Dockerfile
@@ -365,7 +365,7 @@ RUN mkdir -p ${GENIE} &&\
 ###############################################################################
 # Catch2
 ###############################################################################
-CATCH2_VERSION=3.3.1
+CATCH2_VERSION="3.3.1"
 LABEL catch2.version=${CATCH2_VERSION}
 RUN mkdir -p src &&\
     ${__wget} https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VERSION}.tar.gz |\
@@ -386,9 +386,10 @@ RUN mkdir -p src &&\
 #  so I don't think it will be able to be used in arm architecture images.
 #  For this reason, I am omitting it until future development is done.
 ###############################################################################
-LABEL onnx.version=1.15.0
+ONNX_VERSION="1.15.0"
+LABEL onnx.version=${ONNX_VERSION}
 #RUN mkdir -p src &&\
-#    ${__wget} https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.15.0.tar.gz |\
+#    ${__wget} https://github.com/microsoft/onnxruntime/archive/refs/tags/v${ONNX_VERSION}.tar.gz |\
 #      ${__untar} &&\
 #    cd src &&\
 #    ./build.sh \
@@ -412,7 +413,7 @@ RUN set -x ;\
     fi &&\
     mkdir -p src &&\
     release_stub="https://github.com/microsoft/onnxruntime/releases/download" &&\
-    onnx_version="1.15.0" &&\
+    onnx_version="${ONNX_VERSION}" &&\
     ${__wget} ${release_stub}/v${onnx_version}/onnxruntime-linux-${onnx_arch}-${onnx_version}.tgz |\
       ${__untar} &&\
     install -D -m 0644 -t ${__prefix}/lib src/lib/* &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -345,15 +345,17 @@ RUN install-ubuntu-packages \
     libtool
 
 
-ENV GENIE_VERSION=3_02_00
+ENV GENIE_VERSION=3.02.00
 #ENV GENIE_REWEIGHT_VERSION=1_02_00
 ENV GENIE=/usr/local/src/GENIE/Generator
-ENV GENIE_DOT_VERSION="$(sed 's,_,\.,g' <<< $GENIE_VERSION )"
-LABEL genie.version=${GENIE_DOT_VERSION}
+#ENV GENIE_DOT_VERSION="$(sed 's,_,\.,g' <<< $GENIE_VERSION )"
+LABEL genie.version=${GENIE_VERSION}
 
+SHELL ["/bin/bash", "-c"]
 
 RUN mkdir -p ${GENIE} &&\
-    ${__wget} https://github.com/GENIE-MC/Generator/archive/refs/tags/R-${GENIE_VERSION}.tar.gz |\
+    export ENV GENIE_GET_VERSION="$(sed 's,\.,_,g' <<< $GENIE_VERSION )" &&\ 
+    ${__wget} https://github.com/GENIE-MC/Generator/archive/refs/tags/R-${GENIE_GET_VERSION}.tar.gz |\
       ${__untar_to} ${GENIE} &&\
     cd ${GENIE} &&\
     ./configure \
@@ -367,6 +369,8 @@ RUN mkdir -p ${GENIE} &&\
     && \
     make -j$NPROC && \
     make -j$NPROC install
+
+SHELL ["/bin/sh", "-c"]
 
 ###############################################################################
 # Catch2


### PR DESCRIPTION
I am changing stuff in the Dockerfile, here are the details. 

### What new packages does this PR add to the development container?
None. Instead it makes sure we define labels based on the same version number variable as we use for building the container. This closes #77 .

## Check List
- [x] I successfully built the container using docker
```
# outline of container build instructions
cd docker
git checkout origin iss77
docker build . -t ldmx/local:dockerIss77
```
- [x] I was able to build ldmx-sw using this new container build
```
# outline of build instructions
ldmx use local dockerIss77
cd ldmx-sw
mkdir build
cd build
ldmx cmake ..
ldmx make install
```
- [x] I was able to test run a small simulation and reconstruction inside this container
```
# outline of test instructions
cd $LDMX_BASE/ldmx-sw/build
ldmx ctest
cd ..
for c in `ls */test/*.py`; do echo -e "\n --------------- \nTesting with $c " ; echo ; ldmx fire $c ; done
```
- [x] I was able to successfully retrieve the version labels
```
docker inspect ldmx/local:dockerIss77
[...]
            "Labels": {
                "catch2.version": "3.3.1",
                "eigen.version": "3.4.0",
                "geant4.version": "LDMX.10.2.3_v0.5",
                "genie.version": "3.02.00",
                "lhapdf.version": "6.5.3",
                "onnx.version": "1.15.0",
                "org.opencontainers.image.ref.name": "ubuntu",
                "org.opencontainers.image.version": "22.04",
                "pythia.version": "6.428",
                "root.version": "6.22.08",
                "ubuntu.version": "22.04",
                "xercesc.version": "3.2.4"
            },
[...]
```
