### PR TITLE
Optionally use custom Geant4

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -51,5 +51,14 @@ export MPLCONFIGDIR=$LDMX_BASE/.config/matplotlib
 # go to first argument
 cd "$1"
 
+# Developer option: If a custom geant4 install is to be used, source the
+# environment script from that install
+#
+# Note: Use with care!
+# The custom Geant4 install still needs to have been built with the same
+# container environment
+if [ -n "$LDMX_CUSTOM_GEANT4" ]; then
+   source $LDMX_CUSTOM_GEANT4/bin/geant4.sh
+fi
 # execute the rest as a one-liner command
 eval "${@:2}"


### PR DESCRIPTION
This resolves #81  

## Check List
- [x] I successfully built the container using docker
- [x] I was able to build ldmx-sw using this new container build

- [x] I was able to test run a small simulation and reconstruction inside this container
- [x] I was able to successfully use the new packages. Explain what you did to test them below:

Built a custom version of Geant4 under ldmx-sw/install/custom_g4/debug, ran 
```shell 

ldmx setenv LDMX_CUSTOM_GEANT4=/path/to/ldmx-sw/install/custom_g4/debug 
ldmx gdb --args fire ... 
```

Which gave me a debug version of Geant4 :) 
