### PR TITLE
bump Geant4 patch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -239,7 +239,7 @@ ENV CLING_STANDARD_PCH=none
 # Assumptions
 #  - GEANT4 defined to be a release of geant4 or LDMX's fork of geant4
 ###############################################################################
-ENV GEANT4=LDMX.10.2.3_v0.5
+ENV GEANT4=LDMX.10.2.3_v0.6
 ENV G4DATADIR="${__prefix}/share/geant4/data"
 LABEL geant4.version="${GEANT4}"
 RUN __owner="geant4" &&\


### PR DESCRIPTION
This small patch to Geant4 is helpful for biased production of samples in volumes upstream of the target and does not affect any of our current samples focused on production (biased or not) within the target or downstream volumes.

I expect the ldmx-sw tests to fail since UMN IT still hasn't resolved the issue with Jeremy's public site hosted there. I will manually check that those tests are the only tests apart of `ctest` that fail.