### PR TITLE
Add shap to ML training/testing libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -428,8 +428,7 @@ RUN ldconfig -v
 # Extra python packages for analysis
 ###############################################################################
 COPY ./python_packages.txt /etc/python_packages.txt
-RUN python3 -m pip install --no-cache-dir --break-system-packages --requirement /etc/python_packages.txt
-
+RUN python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed --requirement /etc/python_packages.txt
 
 # Optional tools and developer utilities
 #

--- a/python_packages.txt
+++ b/python_packages.txt
@@ -14,3 +14,4 @@ numba
 # ML training/testing libraries
 scikit-learn
 xgboost
+shap


### PR DESCRIPTION
I am adding a new package to the container, here are the details.

Resolves https://github.com/LDMX-Software/dev-build-context/issues/160

### What new packages does this PR add to the development image?
- `shap`

## Check List
- [x] I successfully built the container using docker
<!--
cd dev-build-context 
git checkout my-updates
docker build . -t ldmx/local:temp-tag
-->

- [x] I was able to successfully use the new packages.
<!-- Explain what you did to test them below. -->

```
docker build . -t ldmx/local:temp-tag
docker run -it --rm -v $PWD:$PWD -w $PWD ldmx/local:temp-tag
python3 -c "import shap"
root@1ae77df9afa4:/tmp/dev-build-context# 
```

So it works
