### PR TITLE
Add `ruff` for python formatting

### DIFF
--- a/python_packages.txt
+++ b/python_packages.txt
@@ -15,3 +15,4 @@ numba
 scikit-learn
 xgboost
 shap
+ruff


### PR DESCRIPTION
I am adding a new package to the container, here are the details.

### What new packages does this PR add to the development image?
- `ruff`

## Check List
- [x] I successfully built the container using docker
<!--
cd dev-build-context 
git checkout my-updates
docker build . -t ldmx/local:temp-tag
-->

- [x] I was able to successfully use the new packages.
<!-- Explain what you did to test them below. -->

```
Black-Max:dev-build-context blackmac$ docker run -it --rm -v $PWD:$PWD -w $PWD ldmx/local:temp-tag
python3 -c "importroot@189453ada55c:/tmp/dev-build-context# python3 -c "import ruff"
root@189453ada55c:/tmp/dev-build-context# ruff
Ruff: An extremely fast Python linter and code formatter.

Usage: ruff [OPTIONS] <COMMAND>

Commands:
  check    Run Ruff on the given files or directories
  rule     Explain a rule (or all rules)
  config   List or describe the available configuration options
  linter   List all supported upstream linters
  clean    Clear any caches in the current directory and any subdirectories
  format   Run the Ruff formatter on the given files or directories
  server   Run the language server
  analyze  Run analysis over Python source code
  version  Display Ruff's version
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help (see more with '--help')
  -V, --version  Print version

Log levels:
  -v, --verbose  Enable verbose logging
  -q, --quiet    Print diagnostics, but nothing else
  -s, --silent   Disable all logging (but still exit with status code "1" upon detecting diagnostics)

Global options:
      --config <CONFIG_OPTION>  Either a path to a TOML configuration file (`pyproject.toml` or `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might find in a `ruff.toml` configuration file) overriding a
                                specific configuration option. Overrides of individual settings using this option always take precedence over all configuration files, including configuration files that were also specified
                                using `--config`
      --isolated                Ignore all configuration files
      --color <WHEN>            Control when colored output is used [possible values: auto, always, never]

For help with a specific command, see: `ruff help <command>`.

```