### PR TITLE
Enforce gcc13 for LHAPDF too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN mkdir src &&\
     ${__wget} https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.5.5.tar.gz |\
       ${__untar} &&\
     cd src &&\
-    ./configure --disable-python --prefix=${__prefix} &&\
+    CC=gcc-13 CXX=g++-13 ./configure --disable-python --prefix=${__prefix} &&\
     make -j$NPROC install &&\
     cd ../ &&\
     rm -rf src


### PR DESCRIPTION
Not a 100% how this happened (*) but on trunk the build failed:
https://github.com/LDMX-Software/dev-build-context/actions/runs/26589468131

(*) I think in the PR we prob still had a cached layer for the LHAPDF

In this PR now I enforce LHAPD uses gcc13 too